### PR TITLE
handle missing rois

### DIFF
--- a/src/napari_steinpose/_reader.py
+++ b/src/napari_steinpose/_reader.py
@@ -145,10 +145,36 @@ def read_mcd(path, acquisition_id=0, rescale_percentile=True, planes_to_load=Non
 
     return data, channels, num_acquisitions, names
 
-def get_actual_num_acquisition(acquisitions):
-    """Keep only acquisitions where number of channels is larger than zero. 
+def get_actual_num_acquisition(acquisitions, path=None):
+    """
+    Keep only acquisitions where number of channels is larger than zero. 
     This is to avoid acquisitions where the stage was moved but no image was taken.
-    This assumes that missing acquisitions are at the end of the list."""
+    This assumes that missing acquisitions are at the end of the list
+    
+    Parameters
+    ----------
+    acquisitions : list of Acquisition
+        The acquisitions to check.
+    path : str
+        Path to mcd file
+
+    Returns
+    -------
+    num_acquisitions : int
+        The number of acquisitions in the mcd file.
+    
+    """
+
+    if acquisitions is None:
+        if path is not None:
+            path = Path(path)
+        else:
+            raise ValueError("Either acquisitions or path must be provided.")
+        if path.suffix == ".mcd":
+            with MCDFile(path) as f:
+                acquisitions = f.slides[0].acquisitions
+        else:
+            raise ValueError("File is not an mcd file.")
 
     num_acquisitions_all = [x.num_channels for x in acquisitions]
     num_acquisitions = [x for x in num_acquisitions_all if x > 0]

--- a/src/napari_steinpose/_reader.py
+++ b/src/napari_steinpose/_reader.py
@@ -145,7 +145,7 @@ def read_mcd(path, acquisition_id=0, rescale_percentile=True, planes_to_load=Non
 
     return data, channels, num_acquisitions, names
 
-def get_actual_num_acquisition(acquisitions, path=None):
+def get_actual_num_acquisition(acquisitions=None, path=None):
     """
     Keep only acquisitions where number of channels is larger than zero. 
     This is to avoid acquisitions where the stage was moved but no image was taken.

--- a/src/napari_steinpose/imc_analysis.py
+++ b/src/napari_steinpose/imc_analysis.py
@@ -6,7 +6,7 @@ import pandas as pd
 import numpy as np
 import yaml
 from readimc import MCDFile
-from ._reader import read_mcd
+from ._reader import read_mcd, get_actual_num_acquisition
 from aicsimageio.writers import OmeTiffWriter
 from aicsimageio import AICSImage
 from cellpose import models
@@ -277,7 +277,7 @@ def create_images_file(file_list_mcd, export_path):
     for img_file in file_list_mcd:
         if img_file.suffix == '.mcd':
             with MCDFile(img_file) as f:
-                num_acquisitions = len(f.slides[0].acquisitions)
+                num_acquisitions = get_actual_num_acquisition(f.slides[0].acquisitions)
                 
                 for i in range(num_acquisitions):
                     acquisition = f.slides[0].acquisitions[i]  # first acquisition of first slide

--- a/src/napari_steinpose/steinpose_widget.py
+++ b/src/napari_steinpose/steinpose_widget.py
@@ -623,7 +623,8 @@ class SteinposeWidget(QWidget):
         curr_proj = self.proj[self.qcbox_projection_method.currentText()]
 
         for f in file_list:
-            for acq in range(self.num_acquisitions):
+            _, _, current_num_acquisition, _ = read_mcd(path=f, only_metadata=True)
+            for acq in range(current_num_acquisition):
                 print(f'Running cellpose on {f.name} acquisition {acq}')
                 _ = run_cellpose(
                     image_path=f,


### PR DESCRIPTION
This PR solves the issue raised in #2 where rois present in the metadata were not actually acquired because the acquisition run was aborted. The solution of this PR is to check the number of channels of each roi. Non-acquired rois have 0 channels and can therefore be removed. Now when querying the number of rois of a dataset, only the rois with n_channels > 0 are considered.

This PR also fixes a potential problem when running the analysis over a folder. Instead of assuming that all files have the same number of rois, now this number is set separately for each file.